### PR TITLE
Fix regexp petterns

### DIFF
--- a/draft-ietf-mile-jsoniodef-12.xml
+++ b/draft-ietf-mile-jsoniodef-12.xml
@@ -1215,8 +1215,8 @@ SpecID = "urn:ietf:params:xml:ns:mile:mmdef:1.2" /  "private"
 IDtype = text .regexp "[a-zA-Z_][a-zA-Z0-9_.-]*"
 IDREFType = IDtype
 URLtype = uri
-TimeZonetype = text .regexp "Z|[\+\-](0[0-9]|1[0-4]):[0-5][0-9]"
-PortlistType = text .regexp "\\d+(\\-\\d+)?(,\\d+(\\-\\d+)?)*"
+TimeZonetype = text .regexp "Z|[\\+\\-](0[0-9]|1[0-4]):[0-5][0-9]"
+PortlistType = text .regexp "[0-9]+(\\-[0-9]+)?(,[0-9]+(\\-[0-9]+)?)*"
 action = "nothing" / "contact-source-site" / "contact-target-site" /
          "contact-sender" / "investigate" / "block-host" /
          "block-network" / "block-port" / "rate-limit-host" /
@@ -2053,7 +2053,7 @@ AttackPhase = {
     "DATETIME": {"type": "string","format": "date-time"},
     "BYTE": {"type": "string"},
     "PortlistType": {
-      "type": "string","pattern": "\\d+(\\-\\d+)?(,\\d+(\\-\\d+)?)*"},
+      "type": "string","pattern": "[0-9]+(\\-[0-9]+)?(,[0-9]+(\\-[0-9]+)?)*"},
     "TimeZonetype": {
       "type":"string","pattern":"Z|[\\+\\-](0[0-9]|1[0-4]):[0-5][0-9]"},
     "URLtype": {


### PR DESCRIPTION
- Replaced `\\d` with `[0-9]+`. 
- Made the notation of back-slash escape consistent in both cddl and json-schema

According to https://www.w3.org/TR/xmlschema11-2/, `\d` in regexp matches numbers base on Unicode property.
It means that `\d` can match non-ascii digits, and it doesn't suit to express port numbers.

This pull request includes only updating on `draft-ietf-mile-jsoniodef-12.xml`, and doesn't include updating on `.txt.pdf` and `.txt` which may be automatically derived from `.xml` file.
Please let me know if I should include updates on other files in this pull request.